### PR TITLE
Fix the Wrong Command Line in Readme.

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -13,8 +13,5 @@ For rtsp-server do:
 
 For rtsp-client do:
 
-`ffmpeg -rtsp_transport tcp -i rtsp://10.96.10.1:554/mystream -c copy output.mp4`
-
-
-
+`ffmpeg -rtsp_transport udp -i rtsp://10.96.10.1:554/mystream -c copy output.mp4`
 


### PR DESCRIPTION
The ffmpeg program in RTSP client side will be failed with parameter "-rtsp_transport tcp".

Correct transport method is UDP, or omit this parameter and let ffmpeg choose it automatically..

Signed-off-by: Han Qiang <qiang.han@intel.com>